### PR TITLE
Remove unsupported Ruby version from Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@
 # versions of RuboCop, may require this file to be generated again.
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Offense count: 3
 Lint/AmbiguousOperator:


### PR DESCRIPTION
Ruby 2.3 is no longer supported in Rubocop in versions 0.82 and greater.