### PR TITLE
Restrict Rubocop versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 ## enable this line to run benchmarks
 # gem "viiite"
 
-gem "rubocop"
+gem "rubocop", "~> 0.82.0"
 gem "simplecov"


### PR DESCRIPTION
Rubocop has many breaking changes fast, its better to restrict its version in the application to avoid causing unintended breaks for users.